### PR TITLE
feat(login): ログイン画面を作成

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,4 +1,10 @@
 {
   "extends": ["stylelint-config-standard"],
-  "ignoreFiles": ["**/node_modules/**"]
+  "ignoreFiles": ["**/node_modules/**"],
+  "rules": {
+    "at-rule-no-unknown": [
+      true,
+      { "ignoreAtRules": ["include", "mixin", "each"] }
+    ]
+  }
 }

--- a/src/components/page/login/Login.module.scss
+++ b/src/components/page/login/Login.module.scss
@@ -1,0 +1,10 @@
+.container {
+  width: 1280px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.login {
+  display: table;
+  margin: 0 auto;
+}

--- a/src/components/page/login/Login.tsx
+++ b/src/components/page/login/Login.tsx
@@ -1,0 +1,45 @@
+import Head from 'next/head';
+
+import styles from './Login.module.scss';
+
+import { Header } from 'src/components/ui/Header';
+import { FormEvent } from 'react';
+
+export const Login = () => {
+  const login = (e: FormEvent) => {
+    e.preventDefault();
+    alert('ログインしました。');
+  };
+
+  return (
+    <>
+      <Head>
+        <title key="title">ログイン | Profile Book</title>
+      </Head>
+
+      <Header />
+      <main>
+        <div className={styles.container}>
+          <section className={styles.login}>
+            <h1>ログイン</h1>
+            <form onSubmit={login}>
+              <div>
+                <label>
+                  <p>メールアドレス</p>
+                  <input type="email" placeholder="メールアドレス" />
+                </label>
+              </div>
+              <div>
+                <label>
+                  <p>パスワード</p>
+                  <input type="password" placeholder="パスワード" />
+                </label>
+              </div>
+              <button>ログイン</button>
+            </form>
+          </section>
+        </div>
+      </main>
+    </>
+  );
+};

--- a/src/components/page/top/Top.module.scss
+++ b/src/components/page/top/Top.module.scss
@@ -1,13 +1,3 @@
-.header {
-  background-color: #999;
-  padding: 10px;
-}
-
-.header-title {
-  font-size: 20px;
-  font-weight: 700;
-}
-
 .container {
   width: 1280px;
   margin: 0 auto;
@@ -34,6 +24,10 @@
 }
 
 .to-login-button {
-  display: block;
+  display: table;
+  text-decoration: none;
+  background-color: #000;
+  color: #fff;
   margin: 0 auto;
+  padding: 10px 20px;
 }

--- a/src/components/page/top/Top.tsx
+++ b/src/components/page/top/Top.tsx
@@ -1,7 +1,10 @@
 import Image from 'next/image';
 import Head from 'next/head';
+import Link from 'next/Link';
 
 import styles from './Top.module.scss';
+
+import { Header } from 'src/components/ui/Header';
 
 export const Top = () => {
   return (
@@ -9,9 +12,8 @@ export const Top = () => {
       <Head>
         <title key="title">Top | Profile Book</title>
       </Head>
-      <header className={styles.header}>
-        <p className={styles['header-title']}>Profile Book</p>
-      </header>
+
+      <Header />
       <main>
         <div className={styles.container}>
           <div className={styles.mainvisual}>
@@ -29,8 +31,9 @@ export const Top = () => {
             メンバーのことを知ってみよう！
           </p>
         </div>
-        {/* TODO: ログイン画面作成後Linkに変更する */}
-        <button className={styles['to-login-button']}>ログインする</button>
+        <Link href="/login">
+          <a className={styles['to-login-button']}>ログインする</a>
+        </Link>
       </main>
     </>
   );

--- a/src/components/ui/Header/Header.module.scss
+++ b/src/components/ui/Header/Header.module.scss
@@ -1,0 +1,20 @@
+.header {
+  background-color: #999;
+  padding: 10px;
+}
+
+@mixin base-header-title {
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.header-title {
+  @include base-header-title();
+}
+
+.header-title-link {
+  @include base-header-title();
+
+  text-decoration: none;
+  color: #000;
+}

--- a/src/components/ui/Header/Header.tsx
+++ b/src/components/ui/Header/Header.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/Link';
+import { useRouter } from 'next/dist/client/router';
+
+import styles from './Header.module.scss';
+
+export const Header = () => {
+  const router = useRouter();
+  return (
+    <header className={styles.header}>
+      {router.pathname === '/' ? (
+        <p className={styles['header-title']}>Profile Book</p>
+      ) : (
+        <Link href="/">
+          <a className={styles['header-title-link']}>Profile Book</a>
+        </Link>
+      )}
+    </header>
+  );
+};

--- a/src/components/ui/Header/index.ts
+++ b/src/components/ui/Header/index.ts
@@ -1,0 +1,1 @@
+export * from './Header';

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,0 +1,8 @@
+import type { NextPage } from 'next';
+import { Login } from 'src/components/page/login/Login';
+
+const LoginPage: NextPage = () => {
+  return <Login />;
+};
+
+export default LoginPage;


### PR DESCRIPTION
## 目的
- ログイン画面を作成するため

## 変更内容
- [x] ヘッダーをコンポーネント化
- [x] ログイン画面を作成

## 備考
- 構造を揃える意味でcomponents/pageもバレルにした方が良さそう
- 今回は文書構造のみで見た目や振る舞いに関しては後で対応することとした。