### PR TITLE
トップページの見た目を調整

### DIFF
--- a/src/components/page/top/Top.module.scss
+++ b/src/components/page/top/Top.module.scss
@@ -1,5 +1,12 @@
+@import '@variables';
+
 .container {
-  width: 1280px;
+  @include mq('sm') {
+    width: 92vw;
+    margin: 0 4vw;
+  }
+
+  max-width: 1280px;
   margin: 0 auto;
   padding: 20px;
 }

--- a/src/components/page/top/Top.tsx
+++ b/src/components/page/top/Top.tsx
@@ -26,9 +26,9 @@ export const Top = () => {
           </div>
           <h1 className={styles.title}>Profile Book</h1>
           <p className={styles.description}>
-            自分をシェアしよう！
+            自分をシェアしよう
             <br />
-            メンバーのことを知ってみよう！
+            メンバーのことを知ってみよう
           </p>
         </div>
         <Link href="/login">

--- a/src/components/ui/Header/Header.module.scss
+++ b/src/components/ui/Header/Header.module.scss
@@ -1,11 +1,13 @@
 .header {
-  background-color: #999;
+  background-color: var(--color-deep-blue);
   padding: 10px;
+  box-shadow: 0 2px 4px var(--color-shadow);
 }
 
 @mixin base-header-title {
   font-size: 20px;
   font-weight: 700;
+  color: var(--color-white);
 }
 
 .header-title {
@@ -16,5 +18,4 @@
   @include base-header-title();
 
   text-decoration: none;
-  color: #000;
 }

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -1,1 +1,12 @@
 /** グローバルなCSSの設定を記載 */
+:root {
+  --color-light-gray: #eee;
+  --color-deep-blue: #0d47a1;
+  --color-white: #fff;
+  --color-black: #000;
+  --color-shadow: #00000030;
+}
+
+html {
+  background-color: var(--color-light-gray);
+}

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1,0 +1,12 @@
+$breakpoints: (
+  "sm": 576px,
+  "md": 768px,
+  "lg": 992px,
+  "xl": 1200px,
+);
+
+@mixin mq($size) {
+  @media screen and (max-width: #{map-get($breakpoints, $size)}) {
+    @content;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,10 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "paths": {
+      "@variables": ["./src/styles/variables.scss"]
+    },
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## 目的
- トップページの見た目を調整するため

## 備考
- 色周りはCSS変数を使うものとした
- レスポンシブ対応を考慮してメディアクエリ用のmixinを用意した
- 暗黙的な参照を避けるためvariables.scssは全体で読み込むのではなく都度importする形にした
- 参考
https://zenn.dev/catnose99/scraps/5e3d51d75113d3